### PR TITLE
fix: Fix Dockerfile

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,7 +17,11 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # GitHub actions needs permissions to create tmp files.
 #RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo \
 #	-u 1001 ubuntu
-USER ubuntu
-WORKDIR /home/ubuntu
+#USER ubuntu
+#WORKDIR /home/ubuntu
+RUN useradd -rm -d /home/avr_dev -s /bin/bash -g root -G sudo \
+	-u 1001 avr_dev
+USER avr_dev
+WORKDIR /home/avr_dev
 
 	


### PR DESCRIPTION
The working account avr_dev in the Dockerfile received an ACCESS error during checkout. By adding avr_dev to the root and sudo groups the error was fixed.

No footer now.