### PR TITLE
build: Change Docker config file, GitHub Actions conigfile.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,12 @@ on:
         push:
                 branches:
                         - main
+                        - build_makefile  
 permissions:
         contents: read        
 
 jobs:
-        build:
+        build_and_check:
                 runs-on: ubuntu-latest
                 container:
                         image: prexte/avr-gcc:latest

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,7 +17,11 @@ RUN DEBIAN_FRONTEND=noninteractive \
 # GitHub actions needs permissions to create tmp files.
 #RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo \
 #	-u 1001 ubuntu
-USER ubuntu
-WORKDIR /home/ubuntu
+#USER ubuntu
+#WORKDIR /home/ubuntu
+RUN useradd -rm -d /home/avr_dev -s /bin/bash -g root -G sudo \
+	-u 1001 avr_dev
+USER avr_dev
+WORKDIR /home/avr_dev
 
 	


### PR DESCRIPTION
Docker image Ubuntu 24.04 now has avr-gcc user. avr-gcc user belongs to root and sudo groups. GitHub actions config file changed name of it's job from build to build_and_check - for test purposes.

No footer for now.